### PR TITLE
Passing function into rule executor to determine whether to write AAD

### DIFF
--- a/x-pack/plugins/alerting/server/mocks.ts
+++ b/x-pack/plugins/alerting/server/mocks.ts
@@ -73,6 +73,7 @@ const createAlertServicesMock = <
       .mockReturnValue(alertInstanceFactoryMock),
     savedObjectsClient: savedObjectsClientMock.create(),
     scopedClusterClient: elasticsearchServiceMock.createScopedClusterClient(),
+    shouldLogAndScheduleActionsForAlerts: () => true,
   };
 };
 export type AlertServicesMock = ReturnType<typeof createAlertServicesMock>;

--- a/x-pack/plugins/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/plugins/alerting/server/task_runner/task_runner.ts
@@ -317,6 +317,7 @@ export class TaskRunner<
               InstanceContext,
               WithoutReservedActionGroups<ActionGroupIds, RecoveryActionGroupId>
             >(alertInstances),
+            shouldLogAndScheduleActionsForAlerts: () => this.shouldLogAndScheduleActionsForAlerts(),
           },
           params,
           state: alertTypeState as State,

--- a/x-pack/plugins/alerting/server/types.ts
+++ b/x-pack/plugins/alerting/server/types.ts
@@ -75,6 +75,7 @@ export interface AlertServices<
   alertInstanceFactory: (
     id: string
   ) => PublicAlertInstance<InstanceState, InstanceContext, ActionGroupIds>;
+  shouldLogAndScheduleActionsForAlerts: () => boolean;
 }
 
 export interface AlertExecutorOptions<

--- a/x-pack/plugins/rule_registry/server/utils/create_lifecycle_executor.test.ts
+++ b/x-pack/plugins/rule_registry/server/utils/create_lifecycle_executor.test.ts
@@ -349,6 +349,33 @@ describe('createLifecycleExecutor', () => {
       })
     );
   });
+
+  it('skips writing documents when rule execution is cancelled and configs indicate to skip', async () => {
+    const logger = loggerMock.create();
+    const ruleDataClientMock = createRuleDataClientMock();
+    const executor = createLifecycleExecutor(
+      logger,
+      ruleDataClientMock
+    )<{}, TestRuleState, never, never, never>(async (options) => {
+      expect(options.state).toEqual(initialRuleState);
+
+      const nextRuleState: TestRuleState = {
+        aRuleStateKey: 'NEXT_RULE_STATE_VALUE',
+      };
+
+      return nextRuleState;
+    });
+
+    await executor(
+      createDefaultAlertExecutorOptions({
+        params: {},
+        state: { wrapped: initialRuleState, trackedAlerts: {} },
+        shouldLogAndScheduleActionsForAlerts: false,
+      })
+    );
+
+    expect(ruleDataClientMock.getWriter).not.toHaveBeenCalled();
+  });
 });
 
 type TestRuleState = Record<string, unknown> & {

--- a/x-pack/plugins/rule_registry/server/utils/create_lifecycle_executor.ts
+++ b/x-pack/plugins/rule_registry/server/utils/create_lifecycle_executor.ts
@@ -140,7 +140,7 @@ export const createLifecycleExecutor =
     >
   ): Promise<WrappedLifecycleRuleState<State>> => {
     const {
-      services: { alertInstanceFactory },
+      services: { alertInstanceFactory, shouldLogAndScheduleActionsForAlerts },
       state: previousState,
     } = options;
 
@@ -281,7 +281,11 @@ export const createLifecycleExecutor =
     const newEventsToIndex = makeEventsDataMapFor(newAlertIds);
     const allEventsToIndex = [...trackedEventsToIndex, ...newEventsToIndex];
 
-    if (allEventsToIndex.length > 0 && ruleDataClient.isWriteEnabled()) {
+    if (
+      allEventsToIndex.length > 0 &&
+      ruleDataClient.isWriteEnabled() &&
+      shouldLogAndScheduleActionsForAlerts() // This check ensures that rule execution has not been cancelled due to timeout or, if it has whether we still want to proceed with handling alerts after rule timeout
+    ) {
       logger.debug(`Preparing to index ${allEventsToIndex.length} alerts.`);
 
       await ruleDataClient.getWriter().bulk({

--- a/x-pack/plugins/rule_registry/server/utils/create_lifecycle_rule_type.test.ts
+++ b/x-pack/plugins/rule_registry/server/utils/create_lifecycle_rule_type.test.ts
@@ -21,7 +21,7 @@ import { createLifecycleRuleTypeFactory } from './create_lifecycle_rule_type_fac
 
 type RuleTestHelpers = ReturnType<typeof createRule>;
 
-function createRule() {
+function createRule(shouldLogAndScheduleActionsForAlerts: boolean = true) {
   const ruleDataClientMock = createRuleDataClientMock();
 
   const factory = createLifecycleRuleTypeFactory({
@@ -110,6 +110,7 @@ function createRule() {
           alertInstanceFactory,
           savedObjectsClient: {} as any,
           scopedClusterClient: {} as any,
+          shouldLogAndScheduleActionsForAlerts: () => shouldLogAndScheduleActionsForAlerts,
         },
         spaceId: 'spaceId',
         state,
@@ -136,6 +137,26 @@ describe('createLifecycleRuleTypeFactory', () => {
     describe('when writing is disabled', () => {
       beforeEach(() => {
         helpers.ruleDataClientMock.isWriteEnabled.mockReturnValue(false);
+      });
+
+      it("doesn't persist anything", async () => {
+        await helpers.alertWithLifecycle([
+          {
+            id: 'opbeans-java',
+            fields: {
+              'service.name': 'opbeans-java',
+            },
+          },
+        ]);
+
+        expect(helpers.ruleDataClientMock.getWriter().bulk).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    describe('when rule is cancelled due to timeout and config flags indicate to skip actions', () => {
+      beforeEach(() => {
+        helpers = createRule(false);
+        helpers.ruleDataClientMock.isWriteEnabled.mockReturnValue(true);
       });
 
       it("doesn't persist anything", async () => {

--- a/x-pack/plugins/rule_registry/server/utils/create_persistence_rule_type_factory.ts
+++ b/x-pack/plugins/rule_registry/server/utils/create_persistence_rule_type_factory.ts
@@ -23,7 +23,11 @@ export const createPersistenceRuleTypeFactory: CreatePersistenceRuleTypeFactory 
               const numAlerts = alerts.length;
               logger.debug(`Found ${numAlerts} alerts.`);
 
-              if (ruleDataClient.isWriteEnabled() && numAlerts) {
+              if (
+                ruleDataClient.isWriteEnabled() &&
+                numAlerts &&
+                options.services.shouldLogAndScheduleActionsForAlerts() // This check ensures that rule execution has not been cancelled due to timeout or, if it has whether we still want to proceed with handling alerts after rule timeout
+              ) {
                 const commonRuleFields = getCommonAlertFields(options);
 
                 const response = await ruleDataClient.getWriter().bulk({

--- a/x-pack/plugins/rule_registry/server/utils/rule_executor_test_utils.ts
+++ b/x-pack/plugins/rule_registry/server/utils/rule_executor_test_utils.ts
@@ -31,6 +31,7 @@ export const createDefaultAlertExecutorOptions = <
   createdAt = new Date(),
   startedAt = new Date(),
   updatedAt = new Date(),
+  shouldLogAndScheduleActionsForAlerts = true,
 }: {
   alertId?: string;
   ruleName?: string;
@@ -39,6 +40,7 @@ export const createDefaultAlertExecutorOptions = <
   createdAt?: Date;
   startedAt?: Date;
   updatedAt?: Date;
+  shouldLogAndScheduleActionsForAlerts?: boolean;
 }): AlertExecutorOptions<Params, State, InstanceState, InstanceContext, ActionGroupIds> => ({
   alertId,
   createdBy: 'CREATED_BY',
@@ -69,6 +71,7 @@ export const createDefaultAlertExecutorOptions = <
       .alertInstanceFactory,
     savedObjectsClient: savedObjectsClientMock.create(),
     scopedClusterClient: elasticsearchServiceMock.createScopedClusterClient(),
+    shouldLogAndScheduleActionsForAlerts: () => shouldLogAndScheduleActionsForAlerts,
   },
   state,
   updatedBy: null,


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
