### PR TITLE
Add frequency support on legacy action migration

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/rule_actions/legacy_action_migration.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/rule_actions/legacy_action_migration.ts
@@ -169,6 +169,11 @@ export const getUpdatedActionsParams = ({
           ...resOfAction,
           id: actionReference[actionRef].id,
           actionTypeId,
+          frequency: {
+            summary: true,
+            notifyWhen: transformToNotifyWhen(ruleThrottle) ?? 'onThrottleInterval',
+            throttle: transformToAlertThrottle(ruleThrottle),
+          },
         },
       ];
     }, []),


### PR DESCRIPTION
While migrating legacy actions we should add the support for the new `frequency` parameter.